### PR TITLE
Add slug to pages objects for use in templates for relative links

### DIFF
--- a/tasks/libs/sassdown.js
+++ b/tasks/libs/sassdown.js
@@ -112,7 +112,8 @@ exports.groups = function (config) {
         config.groups[file.group].pages.push({
             heading: file.heading,
             group: file.group,
-            path: file.path
+            path: file.path,
+            slug: file.slug
         });
     });
     for (var i=0; i<config.groups.length; i++) {


### PR DESCRIPTION
Useful for constructing navigation links when serving the styleguide from varying directory structures.
