### PR TITLE
Handlebars template charset

### DIFF
--- a/tasks/data/template.hbs
+++ b/tasks/data/template.hbs
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+<meta charset="utf-8" />
 <head>
     <title>{{heading}} &middot; Styleguide</title>
     {{> theme}}


### PR DESCRIPTION
Hi,

i've noticed that the default theme template was missing the charset meta.
Added with `utf-8` as default.
