### PR TITLE
skip empty navigation elements

### DIFF
--- a/tasks/data/template.hbs
+++ b/tasks/data/template.hbs
@@ -42,7 +42,9 @@
                 {{/each}}
                 </ul>
             {{else}}
-                <a href="{{> root}}/{{href}}">{{title}}</a>
+                {{#if href}}
+                    <a href="{{> root}}/{{href}}">{{title}}</a>
+                {{/if}}
             {{/if}}
         {{/each}}
     </div>


### PR DESCRIPTION
![empty-nav-nodes](https://f.cloud.github.com/assets/26371/2158884/01f9c854-949b-11e3-85c9-775db0020ce8.gif)

currently the root of the navigation generate empty nodes. Screenshot display the empty spots on mouseover.
