### PR TITLE
prevent overriding of unordered lists

### DIFF
--- a/tasks/data/theme.css
+++ b/tasks/data/theme.css
@@ -20,7 +20,7 @@ h1 { font-size: 25px; }
 h2 { font-size: 21px; }
 h3 { font-size: 17px; }
 h4 { font-size: 14px; }
-ul, ol { margin-left: 1em; list-style: outside; }
+ul, ol { margin-left: 1em; list-style-position: outside; }
 
 /* Layout */
 .gutter {


### PR DESCRIPTION
`list-style: outside;` overwrites `list-style-type` of `ul` and `ol` elements.

with the result both `ul` and `ol` have 'disc' as `list-style-type`.
for `ul` this is ok, but not for `ol` 

dummy example:

```
/*doc

# Alerts

1. Hide by default
2. Set fixed position

    <div class="alert">
    </div>

*/
.alert {
    border: solid; /* 1 */
    position: fixed; /* 2 */
}
```

after/before screenshot:
![screen shot 2014-02-14 at 12 35 56](https://f.cloud.github.com/assets/26371/2170397/409df540-956c-11e3-83bc-720091ec9910.png)
