### PR TITLE
Add an option, `dryRun` which will make the task exit non-zero if there are missing docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ Default: `false`
 
 *Optional*. When set to true, Sassdown will ignore any files that do not contain matching or valid comment blocks.
 
+#### options.dryRun
+Type: `Boolean`<br/>
+Default: `false`
+
+*Optional*. When set to true, Sassdown will not generate any files, and will exit with status `1` if any files do not contain matching or valid comment blocks.
+
 ### Usage
 
 You will need to use an [expanded files object](http://gruntjs.com/configuring-tasks#building-the-files-object-dynamically), but here is roughly the minimum configuration required.

--- a/tasks/sassdown.js
+++ b/tasks/sassdown.js
@@ -25,11 +25,15 @@ module.exports = function (grunt) {
                 template: null,
                 highlight: null,
                 excludeMissing: false,
+                dryRun: false,
                 commentStart: /\/\*/,
                 commentEnd: /\*\//
             }),
             files: this.files
         };
+        if (Sassdown.config.option.dryRun) {
+            Sassdown.config.option.excludeMissing = true;
+        }
 
         // Subtask: Init (expose module and grunt)
         Sassdown.init(grunt);
@@ -51,6 +55,15 @@ module.exports = function (grunt) {
 
         // Subtask: Trees
         Sassdown.tree();
+
+        if (Sassdown.config.option.dryRun) {
+            if (Sassdown.excluded.length) {
+                grunt.verbose.or.warn('Source files invalid');
+                return false;
+            }
+            grunt.verbose.or.ok('Source files validated');
+            return true;
+        }
 
         // Subtask: Indexing
         grunt.verbose.subhead('Write styleguide index file:');


### PR DESCRIPTION
The `dryRun` command will never output any compiled files. It overrides the existing `excludeMissing` param and uses the list of `excluded` source files to know if there were any errors generated.

Exiting non-zero facilitates adding this to build pipelines
