### PR TITLE
Trim the markup and styles output.

### DIFF
--- a/tasks/data/theme.css
+++ b/tasks/data/theme.css
@@ -124,7 +124,7 @@ ul, ol { margin-left: 1em; list-style-position: outside; }
 }
 .section .markup pre,
 .section .styles pre {
-  padding: 0 20px 20px;
+  padding: 20px;
 }
 .section .markup:before,
 .section .styles:before {

--- a/tasks/libs/sassdown.js
+++ b/tasks/libs/sassdown.js
@@ -212,11 +212,11 @@ module.exports.formatting = function (content, styles) {
         // Show result
         output.result  = content.split(/```/)[1];
         // Show markup
-        output.markup  = '<pre class="hljs"><code>'+hljs.highlight('html', content.split(/```/)[1].split(/```/)[0]).value+'</code></pre>';
+        output.markup  = '<pre class="hljs"><code>'+hljs.highlight('html', content.split(/```/)[1].split(/```/)[0].trim()).value+'</code></pre>';
         // Does styles consist of more than whitespace?
         if (unspace(styles).length > 0) {
             // Show styles
-            output.styles  = '<pre class="hljs"><code>'+hljs.highlight('scss', styles).value+'</code></pre>';
+            output.styles  = '<pre class="hljs"><code>'+hljs.highlight('scss', styles.trim()).value+'</code></pre>';
         }
     }
     // If we don't find code blocks


### PR DESCRIPTION
This trims the output and lets the CSS control the padding on all sides of the output boxes, so it can be changed in a custom theme.
