### PR TITLE
Enables Handlebars Helpers in the template

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,6 +40,7 @@ module.exports = function(grunt) {
                         'test/example/assets/js/*.js',
                     ],
                     readme: 'test/example/assets/sass/readme.md',
+                    //handlebarsHelpers: ['test/helpers/**/*.js'],
                     //theme: 'test/theme.css',
                     //template: 'test/template.hbs'
                     //highlight: 'github'

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ Default: `null`
 
 *Optional*. A path to a Handlebars template file. Will use default Sassdown template if left blank.
 
+#### options.handlebarsHelpers
+Type: `Array`<br/>
+Default: `null`
+
+*Optional*. Array of file paths. The [Handlebars helpers](http://handlebarsjs.com/#helpers) will be available to use in the template. Supports [globbing](http://gruntjs.com/configuring-tasks#globbing-patterns). Supports relative and absolute file paths (eg. `http://`, `https://` or even `file://`).
+
 #### options.theme
 Type: `String`<br/>
 Default: `null`
@@ -233,6 +239,32 @@ Sassdown also provides a series of Handlebars **partials**, which can be used to
 * `{{> assets}}`<br>Outputs a set of `<link />` or `<script>` tags that include assets specified in the Grunt task options.
  
 * `{{> theme}}`<br>Outputs the theme stylesheet, minified, into a `<style>` tag.
+
+### Handlebars helpers
+
+You can add more features to Handlebar templates by using [Helpers](http://handlebarsjs.com/#helpers).
+
+For example you could add a helper that capitalizes all text:
+
+    <big>{{uppercase shoutThis}}</big>
+    
+You load your helpers with the `handlebarsHelpers` option.
+
+    handlebarsHelpers: ['hb-helpers/**/*.js']
+
+The helper module must export a function that does the registration, or else it won't load.
+
+    module.exports = function(Handlebars) {
+        Handlebars.registerHelper('uppercase', function(input) {
+          return typeof input === 'string' ? input.toUpperCase() : input;
+        });
+    };
+    
+    // This also works
+    module.exports = {
+      register: function(Handlebars) {
+        ...
+    }
 
 # Highlight.js
 

--- a/tasks/sassdown.js
+++ b/tasks/sassdown.js
@@ -23,6 +23,7 @@ module.exports = function (grunt) {
                 assets: null,
                 readme: null,
                 template: null,
+                handlebarsHelpers: null,
                 highlight: null,
                 excludeMissing: false,
                 dryRun: false,
@@ -40,6 +41,7 @@ module.exports = function (grunt) {
 
         // Subtask: Scaffold, Template, Theme
         grunt.verbose.subhead('Compile the Handlebars template, theme and syntax highlighter:');
+        Sassdown.registerHandlebarsHelpers();
         Sassdown.scaffold();
         Sassdown.template();
         Sassdown.theme();

--- a/test/helpers/handlebars.lowercase.js
+++ b/test/helpers/handlebars.lowercase.js
@@ -1,0 +1,5 @@
+module.exports.register = function(Handlebars) {
+    Handlebars.registerHelper('lowercase', function(input) {
+        return typeof input === 'string' ? input.toLowerCase() : input;
+    });
+};

--- a/test/helpers/nested-helpers/handlebars.uppercase.js
+++ b/test/helpers/nested-helpers/handlebars.uppercase.js
@@ -1,0 +1,5 @@
+module.exports = function(Handlebars) {
+    Handlebars.registerHelper('uppercase', function(input) {
+        return typeof input === 'string' ? input.toUpperCase() : input;
+    });
+};


### PR DESCRIPTION
In the spirit of the current milestone--to make working with the template easier--I've made it possible to use Handlebars Helpers in the template.

There are two example helpers included in the _test_ folder. See the _README_ for instructions on how to enable them and use them in the template.

Most helpers I saw while doing this that were CommonJS modules used the `module.exports.register` format for loading and registering.
