### PR TITLE
Fix: Iframe height=0 #67

### DIFF
--- a/tasks/data/scripts.js
+++ b/tasks/data/scripts.js
@@ -26,8 +26,8 @@
     var iframes = document.getElementsByTagName('iframe');
     
     for ( var i = 0; i < iframes.length; i++ ){
-        iframes[i].contentDocument.addEventListener('DOMContentLoaded', function () {
-            this.height = this.contentDocument.body.scrollHeight;
+        iframes[i].contentWindow.addEventListener('load', function () {
+            this.height = this.contentWindow.document.body.scrollHeight;
         }.bind(iframes[i]), false);
     }
 


### PR DESCRIPTION
Since CSS can change height of elements we should detect iframe's height on `load` event.
Also using `contentDocument` doesn't work reliably in all browsers.
