### PR TITLE
Different solution for setting height on iframes

### DIFF
--- a/tasks/data/scripts.js
+++ b/tasks/data/scripts.js
@@ -3,6 +3,7 @@
 
     function query (str, context) { return (context || d).querySelector(str); }
     function queryAll (str, context) { return Array.prototype.slice.call((context || d).querySelectorAll(str)); }
+    function generateId () { return (Math.random()+1).toString(36).substring(2); }
 
     // Insert the results
 
@@ -10,27 +11,20 @@
 
     queryAll('.result-placeholder').forEach(function (placeholder) {
         var parent = placeholder.parentNode;
-        var content = resultTemplate.replace('[[body]]', placeholder.innerHTML);
+        var content = resultTemplate
+            .replace('[[body]]', placeholder.innerHTML)
+            .replace('[[onload]]', 'parent.adjustIframeHeight(window.frameElement.id)');
         var iframe = d.createElement('iframe');
         parent.appendChild(iframe);
         parent.removeChild(placeholder);
+        iframe.setAttribute('id', generateId());
         iframe.setAttribute('height', 0);
         var doc = iframe.contentWindow.document;
         doc.open();
         doc.write(content);
         doc.close();
     });
-
-    // Resize the results iframes to match their content height
-
-    var iframes = document.getElementsByTagName('iframe');
     
-    for ( var i = 0; i < iframes.length; i++ ){
-        iframes[i].contentDocument.addEventListener('DOMContentLoaded', function () {
-            this.height = this.contentDocument.body.scrollHeight;
-        }.bind(iframes[i]), false);
-    }
-
     // Toggling navigation folders
 
     queryAll('#nav .heading').forEach(function (heading) {
@@ -53,3 +47,12 @@
         });
     });
 }(document));
+
+// Resizes the given iframe to the height of the content.
+// Must be placed here, will be called from inside the iframe.
+function adjustIframeHeight (id) {
+    setTimeout(function () {
+        var iframe = document.getElementById(id);
+        iframe.height = iframe.contentWindow.document.body.scrollHeight;
+    }, 100);
+}

--- a/tasks/data/template.hbs
+++ b/tasks/data/template.hbs
@@ -75,11 +75,11 @@
 </div>
 
 <script class="result-template" type="text/html">
-  <!DOCTYPE html>
-  <html>
-      <head>{{> assets}}</head>
-      <body>[[body]]</body>
-  </html>
+    <!DOCTYPE html>
+    <html>
+        <head>{{> assets}}</head>
+        <body onload="[[onload]]">[[body]]</body>
+    </html>
 </script>
 
 {{> theme}}


### PR DESCRIPTION
Solves issue in #67 

Previous solution for setting actual height of demo iframes didn't work proberly for some cases since in Chrome (and other browsers) onload event in iframes does not consider attachements (external styles). See: http://www.atalasoft.com/cs/blogs/jake/archive/2009/06/18/events-to-expect-when-dynamically-loading-iframes-in-javascript.aspx

Therfore I implemented a solution which triggers the resize event from within the iframe which works quite well for me. 
