### PR TITLE
< 630px default media-query CSS

### DIFF
--- a/tasks/data/theme.css
+++ b/tasks/data/theme.css
@@ -166,3 +166,67 @@ pre {
   -ms-hyphens: none;
   hyphens: none;
 }
+
+/** Small viewport adjustments **/
+@media only screen and (max-width : 630px) {
+  body {
+    padding: 0;
+  }
+
+  #nav {
+    float: none;
+    margin-bottom: 0;
+    width: 100%;
+  }
+
+  #nav a {
+    border-radius: 0;
+  }
+
+  #nav h1 {
+    font-size: 24px;
+    line-height: 36px;
+    margin: 0;
+    padding-bottom: 0;
+  }
+
+  #nav .heading {
+    border-radius: 0;
+    font-size: 18px;
+    padding: 5px;
+  }
+
+  #nav ul.is-open {
+    background: #f7f7f7;
+    margin-bottom: 0;
+    padding-bottom: 10px;
+  }
+
+  #nav > ul {
+    box-shadow: inset 0 2px 3px 0 rgba(0,0,0,0.2);
+    border-bottom: 1px solid #d0d5c5;
+  }
+
+  #nav ul ul, #nav ul .heading {
+    margin-left: 0px;
+  }
+
+  #nav .is-open li {
+    font-size: 16px;
+    padding-top: 4px;
+  }
+
+  #content {
+    min-width: 0;
+  }
+
+  .section {
+    box-shadow: inset 0 2px 3px 0 rgba(0,0,0,0.2), 0 2px 3px rgba(0,0,0,0.2)
+  }
+
+  .section .comment,
+  .section .result {
+    padding-left: 5px;
+    padding-right: 5px;
+  }
+}


### PR DESCRIPTION
We do a lot of responsive SASS at work, it can be jarring when you get to smaller viewports in sassdown and the content breaks from the nav. 

This is a small customisation to the default CSS to make the nav a bit more compact at smaller sizes, adjust the content padding to give more width, and make the navigation links a little bit bigger for fat fingers like my own.

I'm no designer, so these are merely tweaks to keep everything as uniform with what is already there as possible.

Cheers for the great work on sassdown, and let us know if I need to make any adjustments.
