### PR TITLE
Allow a custom title to be set in the options

### DIFF
--- a/tasks/libs/sassdown.js
+++ b/tasks/libs/sassdown.js
@@ -290,11 +290,9 @@ module.exports.readme = function () {
     var file = {}, html = '';
     // Fill with data
     file.slug  = '_index';
-    file.href  = 'index.html';
-    // Have a custom title?
-    if (Sassdown.config.option.title) { file.title = Sassdown.config.option.title; }
-    else { file.title = 'Styleguide'; }
-
+    file.href  = 'index.html';    
+	// Have a custom title?
+    file.title = Sassdown.config.option.title || 'Styleguide';	
     file.dest  = Sassdown.config.root + file.href;
     // Has a README file been specified?
     if (Sassdown.config.option.readme) {


### PR DESCRIPTION
Check for a custom title value in Sassdown.config.option, use it if present, default to 'Styleguide' if not set.
