### PR TITLE
Check for files to resolve to anything before scaffolding

### DIFF
--- a/tasks/libs/sassdown.js
+++ b/tasks/libs/sassdown.js
@@ -174,6 +174,12 @@ module.exports.include = function (file, dest) {
 };
 
 module.exports.scaffold = function () {
+    // Check if files has resolved to anything
+    if (!Sassdown.config.files.length) {
+        // Fail, because too many things break without a resolved root
+        grunt.fail.warn('No files found to process.');
+    }
+
     // Define a path to destination root
     Sassdown.config.root = Sassdown.config.files[0].orig.dest;
     // Create the destination directory


### PR DESCRIPTION
This resolves a bug where if the files array doesn't resolve anything, sassdown returns `Warning: Cannot read property 'orig' of undefined Use --force to continue.` Which tells the user very little.

To reproduce, change line 50 in Gruntfile.js to something like `cwd: 'test/example/asses/sass/foo' and run `grunt sassdown`.
